### PR TITLE
Fix bugs with missing ATIS and parking brake

### DIFF
--- a/727-230-set.xml
+++ b/727-230-set.xml
@@ -157,6 +157,8 @@
 
   </sim>
 
+  <controls include="Init/controls.xml"/>
+
   <!-- IAHMCOL introduced new instrumentation file to install ADF, Clock, and DME. Old config was transferred there -->
   <instrumentation>
     <path>Aircraft/727-230/Systems/727-230-instrumentation.xml</path>

--- a/Init/controls.xml
+++ b/Init/controls.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<PropertyList>
+
+  <gear>
+    <brake-parking type="double">1.0</brake-parking>
+  </gear>
+
+</PropertyList>
+

--- a/Systems/727-230-instrumentation.xml
+++ b/Systems/727-230-instrumentation.xml
@@ -88,4 +88,18 @@ file, these values will be used (they are hardcoded).
   </inputs>
   </mk-viii>
 
+  <!-- Keep these comm-radio entries at the bottom of this file. Users running
+       Flightgear versions prior to 3.2 do not have the new comm radio code
+       and anything after these entries will be ignored in those versions.
+  -->
+  <comm-radio>
+    <name>comm</name>
+    <number>0</number>
+  </comm-radio>
+
+  <comm-radio>
+    <name>comm</name>
+    <number>1</number>
+  </comm-radio>
+
 </PropertyList>


### PR DESCRIPTION
I've created an Init directory to include any initialization files. I have added controls.xml, but others could include instrumentation.xml, views.xml, etc.
